### PR TITLE
.AppImage hint

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     <br class="clear">
 
     <h1>Setting up Panel Attack on Mac, Linux or Android</h1>
-    <p>Download and install love2d 11.4 for Mac or your distribution of Linux, or the android.apk:<br class="clear">
+    <p>Download and install love2d 11.4 for Mac or your distribution of Linux (use the .AppImage file if you are unsure), or the android.apk:<br class="clear">
       <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>
     </p>
     <p>


### PR DESCRIPTION
Added hint about .AppImage file type for Linux users

rayn asked in help about how to get PA to run on linux and the current love release only offers DL for the linux source and the AppImage. As the AppImage is not marked as linux, unless you're well-versed with linux you may not be aware that it is the correct file or you'd have to go through the process of compiling love using the source which is probably more than we'd ordinarily want to demand even from linux users so I added a hint about the file type.