### PR TITLE
Update setup instructions for love 11.5

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,44 +75,61 @@
 
     <h1>Download the game</h1>
 
-    <p>Panel Attack is very easy to set up. Just download the zip file below, unzip it, and run panel.exe. Set your
-      controls, set your name, and you're ready to go! Click the button below to download the latest version of the
-      game.</p>
-
     <a href="/panel.zip" target="_blank">
       <p class="button">Download panel.zip</p>
     </a>
 
-    <br class="clear">
-
-    <h1>Setting up Panel Attack on Mac, Linux or Android</h1>
-    <p>Download and install love2d 11.4 for Mac or your distribution of Linux (use the .AppImage file if you are unsure), or the android.apk:<br class="clear">
-      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>
-    </p>
-    <p>
-      You can then download the windows release of Panel Attack, unzip it, and change the file extension of the
-      panel.exe from .exe to .love. </p>
-    <p>On your Mac, or Linux machine you should be able to double-click it to run it after that.</p>
-    <p>On Android, use a file browser to open panel.love and choose the love2d app when prompted which app to open the
-      file with. Some file browser apps on Android do not offer this option so you may have to install a different one,
-      e.g. X-plore.
-    </p>
-
-    <h1>Introduction Video</h1>
-    <p>Here's an introduction video, by community member Graff:</p>
-
-    <br class="clear">
+    <p class="clear">Panel Attack is very easy to set up. On Windows, just download the zip file above, unzip it, and run panel.exe. Set your
+      controls, set your name, and you're ready to go!</p>
+    <p>Here's an introduction video for Windows, by community member Graff:</p>
 
     <div class="container1">
       <!--Container to limit container2 width-->
       <div class="container2">
         <!--Container to determine iframe height-->
-        <iframe class="video" src="https://www.youtube.com/embed/NSgZG1dwYSk" frameborder="0"
+        <iframe class="video" src="https://www.youtube.com/embed/lm5zW5yPsr0" frameborder="0"
           allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
       </div>
     </div>
+
     <br class="clear">
 
+    <h1>Setting up Panel Attack on Mac</h1>
+    <p>Download and install love 11.5 for Mac from
+      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+    <br />
+      Download <a href="/panel.zip" target="_blank">panel.zip</a>, unzip it, and change the file extension of
+      <span class="code">panel.exe</span> from .exe to .love.
+    <br />
+      After that you can start the game by doubleclicking <span class="code">panel.love</span>.
+    </p>
+
+    <h1>Setting up Panel Attack on Linux</h1>
+    <p>Download the love 11.5 .AppImage from
+      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+      <br />
+      Right-click the file and select <span class="code">Properties</span> -> <span class="code">Permissions</span>. Check the option that allows the file to run as a program.
+      <br />
+      Download <a href="/panel.zip" target="_blank">panel.zip</a>, unzip it, and change the file extension of
+    <span class="code">panel.exe</span> from .exe to .love.
+    <br />
+      After that you can start the game by dragging and dropping <span class="code">panel.love</span> on top of the AppImage or start the AppImage
+      via the terminal and pass <span class="code">panel.love</span> as the argument.
+    </p>
+
+    <h1>Setting up Panel Attack on Android</h1>
+    <p>Download and install the love 11.5 .apk from
+      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+      <br />
+      The love release in the Play Store is outdated and explicitly not recommended!
+      <br />
+      Download <a href="/panel.zip" target="_blank">panel.zip</a>, unzip it, and change the file extension of
+      <span class="code">panel.exe</span> from .exe to .love.
+      <br />
+      Start the LÖVE Loader app, browse to where you saved <span class="code">panel.love</span> and select it to start.
+    </p>
+
+    <br class="clear">
 
   </div>
   <!--body div-->

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
 
     <h1>Setting up Panel Attack on Mac</h1>
     <p>Download and install love 11.5 for Mac from
-      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+      <a href="https://love2d.org/" target="_blank">https://love2d.org/</a>.
     <br />
       Download <a href="/panel.zip" target="_blank">panel.zip</a>, unzip it, and change the file extension of
       <span class="code">panel.exe</span> from .exe to .love.
@@ -105,8 +105,8 @@
     </p>
 
     <h1>Setting up Panel Attack on Linux</h1>
-    <p>Download the love 11.5 .AppImage from
-      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+    <p>Download the AppImage from
+      <a href="https://love2d.org/" target="_blank">https://love2d.org/</a>.
       <br />
       Right-click the file and select <span class="code">Properties</span> -> <span class="code">Permissions</span>. Check the option that allows the file to run as a program.
       <br />
@@ -118,8 +118,8 @@
     </p>
 
     <h1>Setting up Panel Attack on Android</h1>
-    <p>Download and install the love 11.5 .apk from
-      <a href="https://github.com/love2d/love/releases" target="_blank">https://github.com/love2d/love/releases</a>.
+    <p>Download and install the Android APK from
+      <a href="https://love2d.org/" target="_blank">https://love2d.org/</a>.
       <br />
       The love release in the Play Store is outdated and explicitly not recommended!
       <br />

--- a/style.css
+++ b/style.css
@@ -285,11 +285,11 @@ p.q {
 .code {
   display: inline-block;
   background-color: #eee;
-  padding: 5px;
+  padding: 2px;
   border: 1px solid #ddd;
-  border-radius: 4px;
-  margin-top: 5px;
-  margin-bottom: 5px;
+  border-radius: 1px;
+  margin-top: 2px;
+  margin-bottom: 2px;
   font-size: 16px;
 }
 


### PR DESCRIPTION
Given how our recommendations changed I also split up the instructions for each OS separately.
The introduction video has been moved further to the top for visibility and I also changed the YT link to the one that Sho sneak-changed on live.
I also changed the formatting for the `code` boxes a bit and made it so that the setup instructions don't have such big gaps between lines.